### PR TITLE
Clones the registry object rather than sharing references.

### DIFF
--- a/lib/ramstorage.js
+++ b/lib/ramstorage.js
@@ -41,12 +41,13 @@ function RAMStorage(config) {
 
 RAMStorage.prototype = {
     /**
-     * Save the registry (just keeps a reference in the object in this storage).
+     * Save the registry (keeps a clone in this storage).
      * 
      * @param <Object> updated registry information to save
      */
     saveRegistry: function (updatedRegistry) {
-        this.registry = updatedRegistry;
+        // Abuse the JSON object to clone the registry
+        this.registry = JSON.parse(JSON.stringify(updatedRegistry));
     },
     
     /**
@@ -63,13 +64,14 @@ RAMStorage.prototype = {
     },
     
     /**
-     * Retrieve the registry. Since this one is just passing back a reference,
+     * Retrieve the registry. Since this one is just passing back an object clone,
      * this happens synchronously. No errors are possible with this implementation.
      *
      * @param <Function> callback(err, registry)
      */
     getRegistry: function (callback) {
-        callback(null, this.registry);
+        // Abuse the JSON object to clone the registry
+        callback(null, JSON.parse(JSON.stringify(this.registry)));
     }
 };
 


### PR DESCRIPTION
This better mimics the semantics of a real world storage (as suggested by @njx).
