### PR TITLE
Optionally keeps track of Brackets compatibility info per version.

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -145,6 +145,13 @@ function addPackage(packagePath, userID, callback) {
             registry[result.metadata.name] = entry;
         }
         
+        // Keep track of the Brackets compatibility information per version
+        // so that the client can install the right version for the user's copy
+        // of Brackets
+        if (result.metadata.engines && result.metadata.engines.brackets) {
+            entry.versions[entry.versions.length - 1].brackets = result.metadata.engines.brackets;
+        }
+        
         storage.saveRegistry(registry);
         storage.savePackage(entry, packagePath);
         callback(null, entry);

--- a/spec/repository.spec.js
+++ b/spec/repository.spec.js
@@ -124,7 +124,10 @@ describe("Repository", function () {
                 metadata: {
                     name: "basic-valid-extension",
                     description: "Less basic than before",
-                    version: "2.0.0"
+                    version: "2.0.0",
+                    engines: {
+                        brackets: ">0.21.0"
+                    }
                 }
             });
             
@@ -133,6 +136,7 @@ describe("Repository", function () {
                 expect(entry.metadata.version).toEqual("2.0.0");
                 expect(entry.versions.length).toEqual(2);
                 expect(entry.versions[1].version).toEqual("2.0.0");
+                expect(entry.versions[1].brackets).toEqual(">0.21.0");
                 
                 // toBeCloseTo with precision -4 means that we're allowing anything less than 10
                 // seconds of difference to pass


### PR DESCRIPTION
The idea with this minor change is to allow Brackets to choose the latest _compatible_ version of an extension.
