### PR TITLE
Throw error if required params are not specified in config.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A node.js-powered registry for Brackets extensions.
 4. Register a GitHub API client app. The callback URL must match the hostname of your
    server. For testing, you could enter `https://localhost:4040/auth/github/callback`.
 4. Also in the `config` folder, create a `config.json` file that contains:
-   * `sessionSecret` - key to use for session hashing
-   * `githubClientId` - client id for registered GitHub app
-   * `githubClientSecret` - client secret for register GitHub app
+   * `sessionSecret` - key to use for session hashing (required)
+   * `githubClientId` - client id for registered GitHub app (required)
+   * `githubClientSecret` - client secret for registered GitHub app (required)
    * `hostname` - hostname of the server, defaults to localhost
    * `securePort` - port to run HTTPS on, defaults to 4040
    * `redirectPort` - port to run HTTP on, just redirects to `securePort`, defaults to 4000

--- a/app.js
+++ b/app.js
@@ -47,9 +47,15 @@ config.securePort = config.securePort || 4040;
 config.redirectPort = config.redirectPort || 4000;
 config.storage = config.storage || "./ramstorage.js";
 
-logging.configure(config);
+// Check for other required config parameters
+["githubClientId", "githubClientSecret", "sessionSecret"].forEach(function (param) {
+    if (!config[param]) {
+        throw new Error("Configuration error: must specify " + param + " in config.json");
+    }
+});
 
-// Configure the repository
+// Configure submodules
+logging.configure(config);
 repository.configure(config);
 
 // Set up Passport for authentication


### PR DESCRIPTION
Fixes #3.

Note that this just checks for a few missing params in config.json. The other params are already checked in the various places that use them (e.g., s3storage.js), and if the entire config.json or cert files are missing, errors will already be thrown by the existing code that tries to read them. (Could make these friendlier but they seem pretty obvious.)

@dangoor 
