### PR TITLE
Registry UI tweaks

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -116,13 +116,43 @@ function _lastVersionDate(object) {
     var result;
     if (object.versions && object.versions.length) {
         result = object.versions[object.versions.length - 1].published;
+        if (result instanceof Date) {
+            result = result.toISOString();
+        }
         if (result) {
-            result = new Date(result).toLocaleDateString();
+            // Just return the ISO-formatted date, which is the portion up to the "T".
+            var dateEnd = result.indexOf("T");
+            if (dateEnd !== -1) {
+                result = result.substr(0, dateEnd);
+            }
         }
     }
     return result || "";
 }
 hbs.registerHelper("lastVersionDate", _lastVersionDate);
+
+function _formatUserId(id) {
+    // Converts our internal user id into something more suitable for display.
+    var friendlyName;
+    if (id) {
+        var nameComponents = id.split(":");
+        friendlyName = nameComponents[1] + " (" + nameComponents[0] + ")";
+    }
+    return friendlyName;
+}
+hbs.registerHelper("formatUserId", _formatUserId);
+
+function _ownerLink(id) {
+    var url;
+    if (id) {
+        var nameComponents = id.split(":");
+        if (nameComponents[0] === "github") {
+            url = "https://github.com/" + nameComponents[1];
+        }
+    }
+    return url;
+}
+hbs.registerHelper("ownerLink", _ownerLink);
 
 function _getSortedRegistry() {
     function getPublishTime(entry) {
@@ -165,15 +195,8 @@ function _respondUnauthorized(req, res, htmlTemplate, data) {
 // Handlers for specific routes
 
 function _index(req, res) {
-    // Convert the username into something more suitable for display.
-    var friendlyName;
-    if (req.user) {
-        var nameComponents = req.user.split(":");
-        friendlyName = nameComponents[1] + " (" + nameComponents[0] + ")";
-    }
-
     _respond(req, res, "index", {
-        user: friendlyName,
+        user: _formatUserId(req.user),
         registry: _getSortedRegistry()
     });
 }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -9,6 +9,8 @@ body {
 .extension-list .ext-desc {
     width: 70%;
 }
-.extension-list .ext-version, .extension-list .ext-date {
+.extension-list .ext-version,
+.extension-list .ext-date,
+.extension-list .ext-author {
     font-size: 0.8em;
 }

--- a/spec/routes.spec.js
+++ b/spec/routes.spec.js
@@ -39,7 +39,9 @@ var _index = routes.__get__("_index"),
     _authFailed = routes.__get__("_authFailed"),
     _logout = routes.__get__("_logout"),
     _upload = routes.__get__("_upload"),
-    _lastVersionDate = routes.__get__("_lastVersionDate");
+    _lastVersionDate = routes.__get__("_lastVersionDate"),
+    _formatUserId = routes.__get__("_formatUserId"),
+    _ownerLink = routes.__get__("_ownerLink");
 
 // Don't map the keys to human-readable strings.
 routes.__set__("_mapError", function (key) { return key; });
@@ -436,23 +438,36 @@ describe("UI helpers", function () {
     it("should get the last published date from a registry entry with one version", function () {
         entry.versions = [{
             version: "1.0.0",
-            published: "2013-04-02T23:35:21.727Z"
+            published: new Date("2013-04-02T23:35:21.727Z")
         }];
-        expect(_lastVersionDate(entry)).toBe(new Date(entry.versions[0].published).toLocaleDateString());
+        expect(_lastVersionDate(entry)).toBe("2013-04-02");
     });
     it("should get the last published date from a registry entry with multiple versions", function () {
         entry.versions = [{
             version: "1.0.0",
-            published: "2013-03-31T23:35:21.727Z"
+            published: new Date("2013-03-31T23:35:21.727Z")
         }, {
             version: "2.0.0",
+            published: new Date("2013-04-02T23:35:21.727Z")
+        }];
+        expect(_lastVersionDate(entry)).toBe("2013-04-02");
+    });
+    it("should get the last published date from a registry entry with the date in string format", function () {
+        entry.versions = [{
+            version: "1.0.0",
             published: "2013-04-02T23:35:21.727Z"
         }];
-        expect(_lastVersionDate(entry)).toBe(new Date(entry.versions[1].published).toLocaleDateString());
+        expect(_lastVersionDate(entry)).toBe("2013-04-02");
     });
     it("should return empty string (and not crash) if some data is missing", function () {
         entry.versions = [];
         expect(_lastVersionDate(entry)).toBe("");
     });
 
+    it("should format the owner name", function () {
+        expect(_formatUserId(entry.owner)).toBe("someuser (github)");
+    });
+    it("should return a link for a github owner", function () {
+        expect(_ownerLink(entry.owner)).toBe("https://github.com/someuser");
+    });
 });

--- a/views/registryList.html
+++ b/views/registryList.html
@@ -1,4 +1,6 @@
 {{#if registry.length}}
+<p>To install an extension, right-click on the link and choose "Copy Link", then paste it into 
+    the <strong>File &gt; Install Extension...</strong> dialog in Brackets.</p>
 <table class="table">
     <tr>
         <th class="ext-name">Extension</th>
@@ -8,10 +10,16 @@
         <tr>
             <td>
                 <a href="https://s3.amazonaws.com/repository.brackets.io/{{metadata.name}}/{{metadata.name}}-{{metadata.version}}.zip">
-                    {{#if metadata.title}}{{metadata.title}}{{else}}{{metadata.name}}{{/if}}
-                    <span class="muted ext-version">{{metadata.version}}</span><br/>
-                    <span class="muted ext-date">{{lastVersionDate this}}</span>
-                </a>
+                    {{#if metadata.title}}{{metadata.title}}{{else}}{{metadata.name}}{{/if}}</a>
+                <span class="muted ext-version">{{metadata.version}}</span><br/>
+                <span class="muted ext-author">
+                    by 
+                    {{#if metadata.author.name}}
+                        {{metadata.author.name}} /
+                    {{/if}}
+                    <a href="{{ownerLink owner}}">{{formatUserId owner}}</a>
+                </span>
+                <span class="muted ext-date">on {{lastVersionDate this}}</span>
             </td>
             <td>
                 {{#if metadata.description}}


### PR DESCRIPTION
- Show author and user name (and shorten date to make room)
- Show extension installation instructions
- Fix link so it only goes around the title, not the whole contents of the table cell

@dangoor
