### PR TITLE
Add JSDoc comments

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -57,7 +57,9 @@ var _stringMap = {
     "UNKNOWN_ERROR"             : "An error occurred, but unfortunately I don't know how to say this nicely:"
 };
 
+/////////////////
 // Error handling
+/////////////////
 
 // From Brackets StringUtils.js.
 /**
@@ -78,10 +80,22 @@ function format(str) {
     });
 }
 
+/**
+ * Returns the string table entry for a given error key, or a generic error if the key is unknown.
+ * @param {string} key The error key to map to a string.
+ * @return {string} The mapped string.
+ */
 function _mapError(key) {
     return (_stringMap[key] || _stringMap.UNKNOWN_ERROR + " " + key);
 }
 
+/**
+ * Formats the given error.
+ * @param {string|Array.<string>} error If it's an array, the first entry is taken as the error key whose string
+ * contains placeholders like {0}, {1}, etc., and the rest are substitution arguments. If it's a string,
+ * then it's assumed to just be a key with no substitutions.
+ * @return {string} The formatted error.
+ */
 function _formatError(err) {
     if (Array.isArray(err)) {
         err[0] = _mapError(err[0]);
@@ -91,6 +105,12 @@ function _formatError(err) {
     }
 }
 
+/**
+ * Converts the given error object into an array of error strings.
+ * @param {Error} err An Error object with a message (which should be an error key) and an optional
+ * "errors" property containing an array of arrays, each of which is suitable to pass to `_formatError()`.
+ * @return {Array.<string>} Array of formatted error strings for display.
+ */
 function _toErrorMessageList(err) {
     var result;
     if (err instanceof Error) {
@@ -112,6 +132,12 @@ function _toErrorMessageList(err) {
 hbs.registerPartial("registryList",
     fs.readFileSync(path.resolve(__dirname, "../views/registryList.html"), "utf8"));
 
+/**
+ * Gets the last version from the given object and returns the short form of its date.
+ * @param {object} object A registry entry with a `versions` array, each of which has a
+ * `published` entry that is either a Date object or an ISO date string.
+ * @return {string} The formatted date.
+ */
 function _lastVersionDate(object) {
     var result;
     if (object.versions && object.versions.length) {
@@ -131,8 +157,12 @@ function _lastVersionDate(object) {
 }
 hbs.registerHelper("lastVersionDate", _lastVersionDate);
 
+/**
+ * Returns a more friendly display form of our internal user id.
+ * @param {string} id A user id in the form "service:id", e.g. "github:njx".
+ * @return {string} A display version in the form "id (service)".
+ */
 function _formatUserId(id) {
-    // Converts our internal user id into something more suitable for display.
     var friendlyName;
     if (id) {
         var nameComponents = id.split(":");
@@ -142,6 +172,12 @@ function _formatUserId(id) {
 }
 hbs.registerHelper("formatUserId", _formatUserId);
 
+/**
+ * Given an internal user id, returns a URL that represents that owner's page on the auth service.
+ * Currently only handles GitHub.
+ * @param {string} id A user id in the form "service:id", e.g. "github:njx".
+ * @return {string} A link to that user's page on the service.
+ */
 function _ownerLink(id) {
     var url;
     if (id) {
@@ -154,6 +190,10 @@ function _ownerLink(id) {
 }
 hbs.registerHelper("ownerLink", _ownerLink);
 
+/**
+ * Returns an array of current registry entries, sorted by the publish date of the latest version of each entry.
+ * @return {Array} Sorted array of registry entries.
+ */
 function _getSortedRegistry() {
     function getPublishTime(entry) {
         return new Date(entry.versions[entry.versions.length - 1].published).getTime();
@@ -173,8 +213,17 @@ function _getSortedRegistry() {
     return sortedEntries;
 }
 
+/////////////////////////////
 // General response functions
+/////////////////////////////
 
+/**
+ * Respond with the given info, rendering it for JSON or HTML depending on what the client wants.
+ * @param {object} req The Express request object.
+ * @param {object} res The Express response object.
+ * @param {string} htmlTemplate The Handlebars template to use if returning HTML.
+ * @param {object} data The data to flow into the template (if HTML) or to return as JSON.
+ */
 function _respond(req, res, htmlTemplate, data) {
     if (req.accepts("html")) {
         res.render(htmlTemplate, data);
@@ -186,13 +235,23 @@ function _respond(req, res, htmlTemplate, data) {
     }
 }
 
+/**
+ * Respond with a 401 Unauthorized code and the appropriate WWw-Authenticate header, along with
+ * a body containing the given info.
+ * @param {object} req The Express request object.
+ * @param {object} res The Express response object.
+ * @param {string} htmlTemplate The Handlebars template to use if returning HTML.
+ * @param {object} data The data to flow into the template (if HTML) or to return as JSON.
+ */
 function _respondUnauthorized(req, res, htmlTemplate, data) {
     res.status(401);
     res.set("WWW-Authenticate", "OAuth realm='https://registry.brackets.io'");
     _respond(req, res, htmlTemplate, data);
 }
 
+///////////////////////////////
 // Handlers for specific routes
+///////////////////////////////
 
 function _index(req, res) {
     _respond(req, res, "index", {
@@ -261,8 +320,14 @@ function _upload(req, res) {
     }
 }
 
+//////////////
 // Route setup
+//////////////
 
+/**
+ * The main route setup function for the Express app.
+ * @param {object} app The Express app to attach our routes to.
+ */
 function setup(app) {
     app.get("/", _index);
     


### PR DESCRIPTION
Originally I didn't think these were necessary, but there are enough subordinate functions in `routes.js` now that it seems worthwhile to have better comments. (`app.js` doesn't have JSDoc comments per se, but it does have explanatory comments on each major setup bit.)

Note that this is a pull into `nj/show-author`.

@dangoor 
