### PR TITLE
Make template helpers reusable in Brackets

### DIFF
--- a/lib/registry_utils.js
+++ b/lib/registry_utils.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*
+ * N.B.: This file is the source for `src/extensibility/registry_utils.js` in Brackets.
+ * We can't use the exact same file currently because Brackets uses AMD-style modules, so the Brackets
+ * version has the AMD wrapper added (and is reindented to avoid JSLint complaints).
+ * If changes are made here, the version in Brackets should be kept in sync.
+ * In the future, we should have a better mechanism for sharing code between the two.
+ */
+
+/*jslint vars: true, plusplus: true, node: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define*/
+
+"use strict";
+
+/**
+ * Gets the last version from the given object and returns the short form of its date.
+ * Assumes "this" is the current template context.
+ * @return {string} The formatted date.
+ */
+exports.lastVersionDate = function () {
+    var result;
+    if (this.versions && this.versions.length) {
+        result = this.versions[this.versions.length - 1].published;
+        if (result) {
+            // Just return the ISO-formatted date, which is the portion up to the "T".
+            var dateEnd = result.indexOf("T");
+            if (dateEnd !== -1) {
+                result = result.substr(0, dateEnd);
+            }
+        }
+    }
+    return result || "";
+};
+
+/**
+ * Returns a more friendly display form of the owner's internal user id.
+ * Assumes "this" is the current template context.
+ * @return {string} A display version in the form "id (service)".
+ */
+exports.formatUserId = function () {
+    var friendlyName;
+    if (this.owner) {
+        var nameComponents = this.owner.split(":");
+        friendlyName = nameComponents[1] + " (" + nameComponents[0] + ")";
+    }
+    return friendlyName;
+};
+
+/**
+ * Given a registry item, returns a URL that represents its owner's page on the auth service.
+ * Currently only handles GitHub.
+ * Assumes "this" is the current template context.
+ * @return {string} A link to that user's page on the service.
+ */
+exports.ownerLink = function () {
+    var url;
+    if (this.owner) {
+        var nameComponents = this.owner.split(":");
+        if (nameComponents[0] === "github") {
+            url = "https://github.com/" + nameComponents[1];
+        }
+    }
+    return url;
+};
+
+/**
+ * Returns an array of current registry entries, sorted by the publish date of the latest version of each entry.
+ * @param {object} registry The unsorted registry.
+ * @return {Array} Sorted array of registry entries.
+ */
+exports.sortRegistry = function (registry) {
+    function getPublishTime(entry) {
+        return new Date(entry.versions[entry.versions.length - 1].published).getTime();
+    }
+    
+    var sortedEntries = [];
+
+    // Sort the registry by last published date (newest first).
+    Object.keys(registry).forEach(function (key) {
+        sortedEntries.push(registry[key]);
+    });
+    sortedEntries.sort(function (entry1, entry2) {
+        return getPublishTime(entry2) - getPublishTime(entry1);
+    });
+    
+    return sortedEntries;
+};

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -27,6 +27,7 @@
 
 var passport = require("passport"),
     repository = require("./repository"),
+    registry_utils = require("./registry_utils"),
     hbs = require("hbs"),
     fs = require("fs"),
     path = require("path");
@@ -133,84 +134,9 @@ function _toErrorMessageList(err) {
 
 hbs.registerPartial("registryList",
     fs.readFileSync(path.resolve(__dirname, "../views/registryList.html"), "utf8"));
-
-/**
- * Gets the last version from the given object and returns the short form of its date.
- * @param {object} object A registry entry with a `versions` array, each of which has a
- * `published` entry that is an ISO date string.
- * @return {string} The formatted date.
- */
-function _lastVersionDate(object) {
-    var result;
-    if (object.versions && object.versions.length) {
-        result = object.versions[object.versions.length - 1].published;
-        if (result) {
-            // Just return the ISO-formatted date, which is the portion up to the "T".
-            var dateEnd = result.indexOf("T");
-            if (dateEnd !== -1) {
-                result = result.substr(0, dateEnd);
-            }
-        }
-    }
-    return result || "";
-}
-hbs.registerHelper("lastVersionDate", _lastVersionDate);
-
-/**
- * Returns a more friendly display form of our internal user id.
- * @param {string} id A user id in the form "service:id", e.g. "github:njx".
- * @return {string} A display version in the form "id (service)".
- */
-function _formatUserId(id) {
-    var friendlyName;
-    if (id) {
-        var nameComponents = id.split(":");
-        friendlyName = nameComponents[1] + " (" + nameComponents[0] + ")";
-    }
-    return friendlyName;
-}
-hbs.registerHelper("formatUserId", _formatUserId);
-
-/**
- * Given an internal user id, returns a URL that represents that owner's page on the auth service.
- * Currently only handles GitHub.
- * @param {string} id A user id in the form "service:id", e.g. "github:njx".
- * @return {string} A link to that user's page on the service.
- */
-function _ownerLink(id) {
-    var url;
-    if (id) {
-        var nameComponents = id.split(":");
-        if (nameComponents[0] === "github") {
-            url = "https://github.com/" + nameComponents[1];
-        }
-    }
-    return url;
-}
-hbs.registerHelper("ownerLink", _ownerLink);
-
-/**
- * Returns an array of current registry entries, sorted by the publish date of the latest version of each entry.
- * @return {Array} Sorted array of registry entries.
- */
-function _getSortedRegistry() {
-    function getPublishTime(entry) {
-        return new Date(entry.versions[entry.versions.length - 1].published).getTime();
-    }
-    
-    var registry = repository.getRegistry(),
-        sortedEntries = [];
-
-    // Sort the registry by last published date (newest first).
-    Object.keys(registry).forEach(function (key) {
-        sortedEntries.push(registry[key]);
-    });
-    sortedEntries.sort(function (entry1, entry2) {
-        return getPublishTime(entry2) - getPublishTime(entry1);
-    });
-    
-    return sortedEntries;
-}
+hbs.registerHelper("lastVersionDate", registry_utils.lastVersionDate);
+hbs.registerHelper("formatUserId", registry_utils.formatUserId);
+hbs.registerHelper("ownerLink", registry_utils.ownerLink);
 
 /////////////////////////////
 // General response functions
@@ -254,15 +180,15 @@ function _respondUnauthorized(req, res, htmlTemplate, data) {
 
 function _index(req, res) {
     _respond(req, res, "index", {
-        user: _formatUserId(req.user),
-        registry: _getSortedRegistry()
+        user: registry_utils.formatUserId.call({owner: req.user}),
+        registry: registry_utils.sortRegistry(repository.getRegistry())
     });
 }
 
 function _registryList(req, res) {
     _respond(req, res, "registryList", {
         layout: false,
-        registry: _getSortedRegistry()
+        registry: registry_utils.sortRegistry(repository.getRegistry())
     });
 }
 

--- a/spec/routes.spec.js
+++ b/spec/routes.spec.js
@@ -26,9 +26,10 @@
 
 "use strict";
 
-var rewire = require("rewire"),
-    routes = rewire("../lib/routes"),
-    fs     = require("fs");
+var rewire         = require("rewire"),
+    routes         = rewire("../lib/routes"),
+    registry_utils = require("../lib/registry_utils"),
+    fs             = require("fs");
 
 var repository = routes.__get__("repository");
 
@@ -39,9 +40,9 @@ var _index = routes.__get__("_index"),
     _authFailed = routes.__get__("_authFailed"),
     _logout = routes.__get__("_logout"),
     _upload = routes.__get__("_upload"),
-    _lastVersionDate = routes.__get__("_lastVersionDate"),
-    _formatUserId = routes.__get__("_formatUserId"),
-    _ownerLink = routes.__get__("_ownerLink");
+    lastVersionDate = registry_utils.lastVersionDate,
+    formatUserId = registry_utils.formatUserId,
+    ownerLink = registry_utils.ownerLink;
 
 // Don't map the keys to human-readable strings.
 routes.__set__("_mapError", function (key) { return key; });
@@ -385,7 +386,7 @@ describe("routes", function () {
     });
 });
 
-describe("UI helpers", function () {
+describe("route utilities", function () {
     var entry;
     
     beforeEach(function () {
@@ -403,7 +404,7 @@ describe("UI helpers", function () {
             version: "1.0.0",
             published: "2013-04-02T23:35:21.727Z"
         }];
-        expect(_lastVersionDate(entry)).toBe("2013-04-02");
+        expect(lastVersionDate.call(entry)).toBe("2013-04-02");
     });
     it("should get the last published date from a registry entry with multiple versions", function () {
         entry.versions = [{
@@ -413,17 +414,17 @@ describe("UI helpers", function () {
             version: "2.0.0",
             published: "2013-04-02T23:35:21.727Z"
         }];
-        expect(_lastVersionDate(entry)).toBe("2013-04-02");
+        expect(lastVersionDate.call(entry)).toBe("2013-04-02");
     });
     it("should return empty string (and not crash) if some data is missing", function () {
         entry.versions = [];
-        expect(_lastVersionDate(entry)).toBe("");
+        expect(lastVersionDate.call(entry)).toBe("");
     });
 
     it("should format the owner name", function () {
-        expect(_formatUserId(entry.owner)).toBe("someuser (github)");
+        expect(formatUserId.call(entry)).toBe("someuser (github)");
     });
     it("should return a link for a github owner", function () {
-        expect(_ownerLink(entry.owner)).toBe("https://github.com/someuser");
+        expect(ownerLink.call(entry)).toBe("https://github.com/someuser");
     });
 });

--- a/views/registryList.html
+++ b/views/registryList.html
@@ -17,15 +17,23 @@
                     {{#if metadata.author.name}}
                         {{metadata.author.name}} /
                     {{/if}}
-                    <a href="{{ownerLink owner}}">{{formatUserId owner}}</a>
+                    <a href="{{ownerLink}}">{{formatUserId}}</a>
                 </span>
-                <span class="muted ext-date">on {{lastVersionDate this}}</span>
+                <span class="muted ext-date">on {{lastVersionDate}}</span>
             </td>
             <td>
                 {{#if metadata.description}}
                     {{metadata.description}}
                 {{else}}
                     <span class="muted"><em>No description</em></span>
+                {{/if}}
+                {{#if metadata.keywords.length}}
+                    <br/>
+                    <span class="ext-keywords">Keywords:
+                    {{#each metadata.keywords}}
+                        {{.}}
+                    {{/each}}
+                    </span>
                 {{/if}}
             </td>
         </tr>


### PR DESCRIPTION
- Refactor them out of routes.js
- Make the helpers Mustache-compatible by making them all just use "this"

Also adds keywords to registry list display.

Note that I didn't end up actually changing the template to use Mustache. I looked into switching to Mustache or Hogan, but neither of them seems to support the "layout" functionality I'm using from `hbs`. I don't think it's worth spending a lot of time to make the actual template consistent with Brackets since the template in the Brackets dialog will end up being significantly different from the one in the web app anyway. However, by making the template helpers all just use `this` instead of taking an argument (and updating the Handlebars version of the template), we can make them work for both Mustache and Handlebars.

This does introduce one little ugly bit: `formatUserId` now takes a context object that has an `owner` property, so the place where we were calling it directly from the `index` route (which originally just passed a user name) now has to cons up an object that looks like this. I didn't feel it was worth refactoring `formatUserId` further to support direct calling in addition to its template helper usage.
