### PR TITLE
adds FileStorage for easier local testing

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,6 +104,11 @@ app.configure(function () {
     app.use(app.router);
     // JSLint doesn't like "express.static" because static is a keyword.
     app.use(express["static"](path.resolve(__dirname, "public")));
+    
+    // This is used for local testing with the FileStorage
+    if (config.directory) {
+        app.use("/files", express["static"](path.resolve(__dirname, config.directory)));
+    }
 });
 
 // Set up routes

--- a/lib/filestorage.js
+++ b/lib/filestorage.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, node: true, nomen: true,
+indent: 4, maxerr: 50 */
+
+"use strict";
+
+var fs = require("fs-extra"),
+    path = require("path");
+
+/**
+ * Stores repository data in files on disk. Used for running on localhost.
+ * This requires dev-dependencies to be installed.
+ *
+ * @param <Object> unused
+ */
+function FileStorage(config) {
+    if (!config.directory) {
+        throw new Error("Directory must be specified in config when using the FileStorage");
+    }
+    this.directory = config.directory;
+    this.extensionsDirectory = this.directory;
+    this.registryFile = path.join(config.directory, "registry.json");
+}
+
+FileStorage.prototype = {
+    /**
+     * Save the registry to disk.
+     * 
+     * @param <Object> updated registry information to save
+     */
+    saveRegistry: function (updatedRegistry) {
+        fs.writeFile(this.registryFile, JSON.stringify(updatedRegistry), "utf8", function (err) {
+            if (err) {
+                console.error(err);
+            }
+        });
+    },
+    
+    /**
+     * Saves a package file to the repository of packages on disk.
+     *
+     * @param <Object> information about the entry from the registry
+     * @param <String> uploadedFile to the file
+     * @param <Function> callback that is called
+     */
+    savePackage: function (entry, uploadedFile, callback) {
+        var version = entry.versions[entry.versions.length - 1].version;
+        var name = entry.metadata.name;
+        var filename = path.join(this.extensionsDirectory, name + "/" + name + "-" + version + ".zip");
+        fs.mkdirsSync(path.dirname(filename));
+        fs.copy(uploadedFile, filename, callback);
+    },
+    
+    /**
+     * Retrieve the registry from disk
+     *
+     * @param <Function> callback(err, registry)
+     */
+    getRegistry: function (callback) {
+        if (!fs.existsSync(this.extensionsDirectory)) {
+            fs.mkdirsSync(this.extensionsDirectory);
+        }
+        if (!fs.existsSync(this.registryFile)) {
+            fs.outputJsonSync(this.registryFile, {});
+        }
+        fs.readJson(this.registryFile, callback);
+    }
+};
+
+exports.Storage = FileStorage;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "jasmine-node": "~1.4.0",
-    "rewire": "~1.1.2"
+    "rewire": "~1.1.2",
+    "fs-extra": "~0.6.3"
   }
 }


### PR DESCRIPTION
By adding these three lines to `config.json`, you can easily test a local repository. Plus, unlike the ramstorage, this puts the files on disk where you can inspect them (and they're saved between runs).

``` javascript
    "repositoryBaseURL": "https://localhost:4040/files",
    "storage": "./filestorage",
    "directory": "datadir"
```

I didn't add unit tests for FileStorage because it's pretty simple and intended for testing only. Note that FileStorage requires fs-extra which is a dev dependencies (`npm install` should get you what you need).
