### PR TITLE
Adds HTTP server for localhost testing

### DIFF
--- a/app.js
+++ b/app.js
@@ -127,7 +127,7 @@ app.configure(function () {
 routes.setup(app, config);
 
 if (config.hostname === "localhost" && config.port) {
-    http.createServer(app).listen(config.port)
+    http.createServer(app).listen(config.port);
     console.log("HTTP Listening on ", config.port);
 } else {
     // Start the HTTPS server


### PR DESCRIPTION
The Brackets registry code has trouble with self-signed certs. This allows you to configure the brackets-registry app on localhost for use with HTTP.
