### PR TITLE
Adds helpURL config variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,13 +39,15 @@ var express = require("express"),
 
 // Load cert and secret configuration
 var config = JSON.parse(fs.readFileSync(path.resolve(__dirname, "config/config.json"))),
-    key, cert;
+    key,
+    cert;
 
 config.hostname = config.hostname || "localhost";
 config.securePort = config.securePort || 4040;
 config.redirectPort = config.redirectPort || 4000;
 config.storage = config.storage || "./ramstorage.js";
 config.repositoryBaseURL = config.repositoryBaseURL || "";
+config.helpURL = config.helpURL || "";
 
 // Load the custom footer HTML from disk, if it's defined.
 if (config.customFooter) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -186,7 +186,8 @@ function _index(req, res) {
     _respond(req, res, "index", {
         user: registry_utils.formatUserId.call({owner: req.user}),
         registry: registry_utils.sortRegistry(repository.getRegistry()),
-        repositoryBaseURL: config.repositoryBaseURL
+        repositoryBaseURL: config.repositoryBaseURL,
+        helpURL: config.helpURL
     });
 }
 
@@ -194,7 +195,8 @@ function _registryList(req, res) {
     _respond(req, res, "registryList", {
         layout: false,
         registry: registry_utils.sortRegistry(repository.getRegistry()),
-        repositoryBaseURL: config.repositoryBaseURL
+        repositoryBaseURL: config.repositoryBaseURL,
+        helpURL: config.helpURL
     });
 }
 

--- a/views/index.html
+++ b/views/index.html
@@ -10,6 +10,9 @@
     {{else}}
         <p>To upload an extension, <a href="/auth/github">sign in via GitHub</a>.</p>
     {{/if}}
+    {{#if helpURL}}
+        <p>Have questions about using the registry? Take a look at the <a href="{{helpURL}}">Help page</a>.</p>
+    {{/if}}
     </div>
 
 <div class="container">

--- a/views/layout.html
+++ b/views/layout.html
@@ -19,6 +19,9 @@
                         {{else}}
                             <a href="/auth/github">Sign in via GitHub</a>
                         {{/if}}
+                        {{#if helpURL}}
+                        | <a href="{{helpURL}}">Help</a>
+                        {{/if}}
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Provides a way to link to a page that gives Extension Registry users more information about using the registry. I have also created an initial stab at the [help page itself](https://github.com/adobe/brackets/wiki/Extension-Registry-Help).

to @njx 
