### PR TITLE
Change requirements now changes the requirements for all versions.

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -308,11 +308,10 @@ function changePackageOwner(entry, newUserID) {
  * @param {string} requirements semver string for the extension's requirements
  */
 function changePackageRequirements(entry, requirements) {
-    var metadata = entry.metadata;
-    if (!metadata.engines) {
-        metadata.engines = {};
-    }
-    metadata.engines.brackets = requirements;
+    var versions = entry.versions;
+    versions.forEach(function (version) {
+        version.brackets = requirements;
+    });
 }
 
 /**

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -120,7 +120,7 @@ $(function () {
             existing = $target.data("existing");
 
         bootbox.prompt({
-            title: "Enter the Brackets version requirements as a semver range " + name,
+            title: "Update version requirements for all versions of your extension. Enter the Brackets version requirements as a semver range " + name,
             value: existing,
             callback: function (requirements) {
                 if (requirements === null) {

--- a/spec/repository.spec.js
+++ b/spec/repository.spec.js
@@ -382,7 +382,9 @@ describe("Repository", function () {
             var registry = repository.__get__("registry");
             repository.changePackageRequirements("basic-valid-extension", username, "<0.38.0", function (err) {
                 expect(err).toBeNull();
-                expect(registry["basic-valid-extension"].metadata.engines.brackets).toEqual("<0.38.0");
+                registry["basic-valid-extension"].versions.forEach(function (version) {
+                    expect(version.brackets).toEqual("<0.38.0");
+                });
                 done();
             });
         });
@@ -400,7 +402,7 @@ describe("Repository", function () {
             repository.changePackageRequirements("basic-valid-extension", "github:unknown", "<0.38.0", function (err) {
                 var registry = repository.__get__("registry");
                 expect(err).not.toBeNull();
-                expect(registry["basic-valid-extension"].metadata.engines).toBeUndefined();
+                expect(registry["basic-valid-extension"].versions[0].brackets).toBeUndefined();
                 done();
             });
         });
@@ -411,7 +413,7 @@ describe("Repository", function () {
             var registry = repository.__get__("registry");
             repository.changePackageRequirements("basic-valid-extension", ADMIN, "<0.38.0", function (err) {
                 expect(err).toBeNull();
-                expect(registry["basic-valid-extension"].metadata.engines.brackets).toEqual("<0.38.0");
+                expect(registry["basic-valid-extension"].versions[0].brackets).toEqual("<0.38.0");
                 done();
             });
         });


### PR DESCRIPTION
By changing the requirements for all versions of an extension, we can ensure that
people with newer versions of Brackets will not get offered an old extension that
won't work (this is the main use case for "Change Requirements").
