### PR TITLE
Fix the internal server error

### DIFF
--- a/app.js
+++ b/app.js
@@ -136,12 +136,12 @@ app.configure(function () {
     app.use(express.bodyParser());
     app.use(express.methodOverride());
     app.use(express.session({ secret: config.sessionSecret }));
+    app.use(passport.initialize());
+    app.use(passport.session());
 
     // this route is accessible from localhost only and no csrf should be applied
     app.post("/stats", downloadData.collectDownloadedData);
 
-    app.use(passport.initialize());
-    app.use(passport.session());
     app.use(express.csrf());
     app.use(function (req, res, next) {
         // Must come before router (so locals are exposed properly) but after the CSRF middleware


### PR DESCRIPTION
There was no bug filed for this issue, but this error happened after we deployed the latest version of the registry with the download data tracking feature.
The order of statements is important for passport, otherwise user couldn't authenticate with github and the server returned with a 500 internal server error.
