### PR TITLE
only allow TLS for SSL connections

### DIFF
--- a/app.js
+++ b/app.js
@@ -172,7 +172,8 @@ if (config.hostname === "localhost" && config.port) {
     https.createServer({
         key: key,
         cert: cert,
-        ca: ca
+        ca: ca,
+        secureProtocol: "TLSv1_method"
     }, app).listen(config.securePort);
     console.log("HTTPS Listening on ", config.securePort);
 


### PR DESCRIPTION
This fixes the POODLE SSLv3 vulnerability
cc @dangoor this is already fixed in the deployed app, but this is the PR for the fix.
