### PR TITLE
better solution to prevent the SSLv3 downgrade attack

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,7 @@ var express = require("express"),
     downloadData = require("./lib/downloadData"),
     logging = require("./lib/logging"),
     _ = require("lodash");
+    constants = require("constants");
 
 // Load cert and secret configuration
 var config = JSON.parse(fs.readFileSync(path.resolve(__dirname, "config/config.json"))),
@@ -173,7 +174,8 @@ if (config.hostname === "localhost" && config.port) {
         key: key,
         cert: cert,
         ca: ca,
-        secureProtocol: "TLSv1_method"
+        secureProtocol: 'SSLv23_method',
+        secureOptions: constants.SSL_OP_NO_SSLv3
     }, app).listen(config.securePort);
     console.log("HTTPS Listening on ", config.securePort);
 


### PR DESCRIPTION
This solution is borrowed from https://chromabits.com/post/poodle-and-nodejs. Thanks @MarcelGerber for bringing this up.
