### PR TITLE
Update package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brackets-registry",
   "description": "node.js-powered server for registering Brackets extensions.",
-  "version": "0.32.0",
+  "version": "0.45.0",
   "homepage": "http://brackets.io",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Guess the package's version should stay in sync with `brackets-extensibility` version.

Btw:
Looks like using [Node >= 0.10.33](http://nodejs.org/changelog.html#v0.10.33) would make our POODLE fix (#65, #66) unnecessary.
Don't know if it's worth it.
