### PR TITLE
Add initial support for github organizations

### DIFF
--- a/lib/registry_utils.js
+++ b/lib/registry_utils.js
@@ -71,8 +71,8 @@ exports.lastVersionDate = function () {
  */
 exports.formatUserId = function () {
     var friendlyName;
-    if (this.owner) {
-        var nameComponents = this.owner.split(":");
+    if (this.user && this.user.owner) {
+        var nameComponents = this.user.owner.split(":");
         friendlyName = nameComponents[1];
     }
     return friendlyName;
@@ -86,8 +86,8 @@ exports.formatUserId = function () {
  */
 exports.ownerLink = function () {
     var url;
-    if (this.owner) {
-        var nameComponents = this.owner.split(":");
+    if (this.user && this.user.owner) {
+        var nameComponents = this.user.owner.split(":");
         if (nameComponents[0] === "github") {
             url = "https://github.com/" + nameComponents[1];
         }

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -31,6 +31,7 @@ var validate = require("brackets-extensibility/package-validator").validate,
     semver   = require("semver"),
     clone    = require("clone"),
     logger   = require("./logging"),
+    user_utils = require("./user_utils"),
     _        = require("lodash");
 
 /**
@@ -238,7 +239,7 @@ function addDownloadDataToPackage(name, newVersionDownloads, recentDownloads) {
  * @param {String} user identifier for the person submitting the file (e.g. "github:someusername")
  * @param {Function} callback (err, entry)
  */
-function addPackage(packagePath, userID, callback) {
+function addPackage(packagePath, user, callback) {
     if (!validConfiguration(callback)) {
         return;
     }
@@ -276,7 +277,7 @@ function addPackage(packagePath, userID, callback) {
             entry = clone(registry[result.metadata.name]);
 
             // Verify that the user is authorized to add this package
-            if (entry.owner !== userID) {
+            if (!user_utils.isOwner(entry, user)) {
                 callback(new Error(Errors.NOT_AUTHORIZED), null);
                 return;
             }
@@ -299,7 +300,7 @@ function addPackage(packagePath, userID, callback) {
             // add
             entry = {
                 metadata: result.metadata,
-                owner: userID,
+                owner: user.owner,
                 versions: [{
                     version: result.metadata.version,
                     published: new Date().toJSON()
@@ -371,14 +372,14 @@ function changePackageRequirements(entry, requirements) {
  * @param {string} name extension name
  * @param {string} userID owner or admin that is submitting the request
  */
-function _packageManipulatorWrapper(func, name, userID) {
+function _packageManipulatorWrapper(func, name, user) {
     var callback = arguments[arguments.length - 1];
     var entry = registry[name];
     if (!entry) {
         callback(new Error(Errors.UNKNOWN_EXTENSION));
         return;
     }
-    if (entry.owner !== userID && config.admins.indexOf(userID) === -1) {
+    if (config.admins.indexOf(user.owner) === -1 && !user_utils.isOwner(entry, user)) {
         callback(new Error(Errors.NOT_AUTHORIZED));
         return;
     }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -28,6 +28,7 @@
 var passport        = require("passport"),
     repository      = require("./repository"),
     registry_utils  = require("./registry_utils"),
+    user_utils      = require("./user_utils"),
     hbs             = require("hbs"),
     fs              = require("fs"),
     path            = require("path"),
@@ -194,9 +195,9 @@ function _getRegistryList(user) {
     var registryList = registry_utils.sortRegistry(repository.getRegistry());
 
     if (user) {
-        var isAdmin = config.admins.indexOf(user) > -1;
+        var isAdmin = config.admins.indexOf(user.owner) > -1;
         registryList = registryList.map(function (entry) {
-            if (isAdmin || entry.owner === user) {
+            if (isAdmin || user_utils.isOwner(entry, user)) {
                 var newEntry = _.clone(entry);
                 newEntry.canAdmin = true;
                 return newEntry;
@@ -216,7 +217,7 @@ function _index(req, res) {
     var registryList = _getRegistryList(req.user);
 
     _respond(req, res, "index", {
-        user: registry_utils.formatUserId.call({owner: req.user}),
+        user: registry_utils.formatUserId.call({user: req.user}),
         registry: registryList,
         repositoryBaseURL: config.repositoryBaseURL,
         helpURL: config.helpURL

--- a/lib/user_utils.js
+++ b/lib/user_utils.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016 - present Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/*jslint vars: true, plusplus: true, nomen: true, node: true, indent: 4, maxerr: 50 */
+
+"use strict";
+
+var _ = require("lodash");
+
+function isUserOwner(entry, user) {
+    return entry.owner === user.owner;
+}
+
+function isUserOrgOwner(entry, user) {
+    return _.some(user.orgs, {
+        login: entry.owner
+    });
+}
+
+function isOwner(entry, user) {
+    return isUserOwner(entry, user) || isUserOrgOwner(entry, user);
+}
+
+function _createFakeUser(username) {
+    return {
+        owner: username,
+        orgs: []
+    };
+}
+
+exports.isUserOwner = isUserOwner;
+exports.isUserOrgOwner = isUserOrgOwner;
+exports.isOwner = isOwner;
+exports._createFakeUser = _createFakeUser;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "filequeue": "~0.5.0",
     "bluebird": "~1.2.4",
     "lodash": "~2.4.1",
-    "request": "~2.31.0",
+    "request": "^2.74.0",
     "request-json": "~0.4.6",
     "temporary": "~0.0.8",
     "commander": "~2.1.0"

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -89,7 +89,7 @@ $(function () {
     $("body").on("click", "button.changeOwner", function (event) {
         var $target = $(event.target),
             name = $target.data("name");
-        bootbox.prompt("Enter the GitHub username of the new owner for " + name, function (newOwner) {
+        bootbox.prompt("Enter the GitHub username / organization of the new owner for " + name, function (newOwner) {
             if (newOwner === null) {
                 return;
             }
@@ -97,7 +97,7 @@ $(function () {
                 displayStatus("info", "No new owner provided. No action taken.");
                 return;
             }
-                
+
             $.ajax("/package/" + name + "/changeOwner", {
                 type: "POST",
                 data: {

--- a/spec/routes.spec.js
+++ b/spec/routes.spec.js
@@ -29,6 +29,7 @@
 var rewire         = require("rewire"),
     routes         = rewire("../lib/routes"),
     registry_utils = require("../lib/registry_utils"),
+    user_utils     = require("../lib/user_utils"),
     fs             = require("fs"),
     path           = require("path");
 
@@ -47,7 +48,8 @@ var _index              = routes.__get__("_index"),
     _rss                = routes.__get__("_rss"),
     lastVersionDate     = registry_utils.lastVersionDate,
     formatUserId        = registry_utils.formatUserId,
-    ownerLink           = registry_utils.ownerLink;
+    ownerLink           = registry_utils.ownerLink,
+    createFakeUser      = user_utils._createFakeUser;
 
 // Don't map the keys to human-readable strings.
 routes.__set__("_mapError", function (key) { return key; });
@@ -169,7 +171,7 @@ describe("routes", function () {
 
         req = createReq();
         uploadReq = createReq();
-        uploadReq.user = "github:someuser";
+        uploadReq.user = createFakeUser("github:someuser");
         uploadReq.files = {
             extensionPackage: {
                 path: "/tmp/s0m3g4rb4g3n4m3",
@@ -219,7 +221,7 @@ describe("routes", function () {
     });
 
     it("should render and inject correct data into the home page when user is authenticated", function () {
-        req.user = "github:someuser";
+        req.user = createFakeUser("github:someuser");
         _index(req, res);
         expect(res.render).toHaveBeenCalled();
         var args = res.render.mostRecentCall.args;
@@ -231,7 +233,7 @@ describe("routes", function () {
     });
 
     it("should render and inject correct data into the home page when admin user is authenticated", function () {
-        req.user = "github:admin";
+        req.user = createFakeUser("github:admin");
         _index(req, res);
         expect(res.render).toHaveBeenCalled();
         var args = res.render.mostRecentCall.args;
@@ -286,7 +288,7 @@ describe("routes", function () {
         _upload(uploadReq, res);
         expect(mockRepository.addPackage).toHaveBeenCalled();
         expect(mockRepository.addPackage.mostRecentCall.args[0]).toBe("/tmp/s0m3g4rb4g3n4m3");
-        expect(mockRepository.addPackage.mostRecentCall.args[1]).toBe("github:someuser");
+        expect(mockRepository.addPackage.mostRecentCall.args[1].owner).toBe("github:someuser");
     });
 
     it("should render upload success page with entry data if upload succeeded", function () {
@@ -442,7 +444,7 @@ describe("routes", function () {
         });
 
         it("should return 404 and render failure page if attempting to delete without giving package name", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             _delete(req, res);
             expect(res.status).toHaveBeenCalledWith(404);
             expect(res.render).toHaveBeenCalled();
@@ -451,7 +453,7 @@ describe("routes", function () {
         });
 
         it("should return 404 and render failure page if attempting to delete unknown package", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "nonexistent-package"
             };
@@ -466,7 +468,7 @@ describe("routes", function () {
         });
 
         it("should return 401 and render failure page if attempting to delete a package without being authorized", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "not-my-package"
             };
@@ -481,7 +483,7 @@ describe("routes", function () {
         });
 
         it("should return 200 and render success page after deleting package", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "good-package"
             };
@@ -506,7 +508,7 @@ describe("routes", function () {
         });
 
         it("should return 404 and render failure page if attempting to changeOwner without giving package name", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             _changeOwner(req, res);
             expect(res.status).toHaveBeenCalledWith(404);
             expect(res.render).toHaveBeenCalled();
@@ -515,7 +517,7 @@ describe("routes", function () {
         });
 
         it("should return 404 and render failure page if attempting to changeOwner unknown package", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "nonexistent-package"
             };
@@ -533,7 +535,7 @@ describe("routes", function () {
         });
 
         it("should return 401 and render failure page if attempting to changeOwner a package without being authorized", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "not-my-package"
             };
@@ -551,7 +553,7 @@ describe("routes", function () {
         });
 
         it("should return 400 and render failure page if attempting to changeOwner a package without specifying a new owner", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "good-package"
             };
@@ -564,7 +566,7 @@ describe("routes", function () {
         });
 
         it("should return 200 and render success page after changing a package owner", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "good-package"
             };
@@ -583,7 +585,7 @@ describe("routes", function () {
         });
 
         it("should automatically add github: to new owner's username", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "good-package"
             };
@@ -612,7 +614,7 @@ describe("routes", function () {
         });
 
         it("should return 404 and render failure page if attempting to changeRequirements without giving package name", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             _changeRequirements(req, res);
             expect(res.status).toHaveBeenCalledWith(404);
             expect(res.render).toHaveBeenCalled();
@@ -621,7 +623,7 @@ describe("routes", function () {
         });
 
         it("should return 404 and render failure page if attempting to changeRequirements unknown package", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "nonexistent-package"
             };
@@ -639,7 +641,7 @@ describe("routes", function () {
         });
 
         it("should return 401 and render failure page if attempting to changeRequirements a package without being authorized", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "not-my-package"
             };
@@ -657,7 +659,7 @@ describe("routes", function () {
         });
 
         it("should return 400 and render failure page if attempting to changeRequirements a package without specifying new requirements", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "good-package"
             };
@@ -670,7 +672,7 @@ describe("routes", function () {
         });
 
         it("should return 200 and render success page after changing package requirements", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "good-package"
             };
@@ -689,7 +691,7 @@ describe("routes", function () {
         });
 
         it("should return 400 for invalid new requirements", function () {
-            req.user = "github:someuser";
+            req.user = createFakeUser("github:someuser");
             req.params = {
                 name: "good-package"
             };
@@ -715,7 +717,7 @@ describe("route utilities", function () {
                 name: "my-extension",
                 version: "1.0.0"
             },
-            owner: "github:someuser"
+            user: createFakeUser("github:someuser")
         };
     });
 


### PR DESCRIPTION
This should hopefully fix https://github.com/adobe/brackets/issues/12464 and help https://github.com/adobe/brackets/issues/8228.
ATM you cannot upload as organization the first time. Before you have to change the owner to an organization and only after the members can upload new versions.
If there is still time for 1.8 would be a nice to have.
Do I need to do some changes to brackets too?
