### PR TITLE
Make npm test work on Windows and upgrade dev dependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "preinstall": "npm install deps/*",
     "start": "node app",
-    "test": "istanbul test jasmine-node spec",
+    "test": "istanbul test node_modules/jasmine-node/bin/jasmine-node spec",
     "jslint": "./node_modules/.bin/jslint ./downloadStats/*.js ./spec/*.js ./lib/*.js"
   },
   "issues": {
@@ -39,10 +39,10 @@
     "commander": "~2.1.0"
   },
   "devDependencies": {
-    "jasmine-node": "~1.13.0",
-    "rewire": "~1.1.3",
-    "fs-extra": "~0.6.4",
-    "istanbul": "~0.2.10",
-    "jslint": "~0.5.0"
+    "fs-extra": "~0.30.0",
+    "istanbul": "~0.4.5",
+    "jasmine-node": "~1.14.5",
+    "jslint": "~0.5.0",
+    "rewire": "~2.5.2"
   }
 }


### PR DESCRIPTION
I had some problems to run tests on Windows, this should fix it.
I've upgraded all dev dependencies but jslint because it is not actually used (if you run it is full of errors) and because I'll replace it with ESLint.