### PR TITLE
Upgraded the request-json version and also updated the check for IPv4 addresses placed inside IPv6 space

### DIFF
--- a/downloadStats/downloadStatsUpdater.js
+++ b/downloadStats/downloadStatsUpdater.js
@@ -139,7 +139,7 @@ function updateExtensionDownloadData(datafile, progress) {
 
     // posting works only from localhost
     var url = protocol + "://localhost:" + httpPort,
-        client = request.newClient(url);
+        client = request.createClient(url);
 
     client.sendFile("/stats", path.resolve(datafile), null, function (err, res, body) {
         if (err) {

--- a/lib/downloadData.js
+++ b/lib/downloadData.js
@@ -33,7 +33,7 @@ function _collectDownloadedData(req, res) {
     logging.debug("Request IP", req.ip);
     logging.debug("Request HOST", req.host);
 
-    if (req.ip === "127.0.0.1" && req.host === "localhost") {
+    if ((req.ip === "::ffff:127.0.0.1" || req.ip === "127.0.0.1") && req.host === "localhost") {
         // read the uploaded JSON data
         var obj = JSON.parse(fs.readFileSync(req.files.file.path));
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bluebird": "~1.2.4",
     "lodash": "~2.4.1",
     "request": "^2.74.0",
-    "request-json": "~0.4.6",
+    "request-json": "~0.6.1",
     "temporary": "~0.0.8",
     "commander": "~2.1.0"
   },


### PR DESCRIPTION
Upgraded request-json dependency to remove the deprecated (used createClient instead of createClient)
And also req.ip returns ::ffff:127.0.0.1 which is an IPv6 address, so added a check for that also, in case we switch to IPv6 in future, we would not have to change the code.
I read about it here http://stackoverflow.com/questions/29411551/express-js-req-ip-is-returning-ffff127-0-0-1